### PR TITLE
GEp disk space reduced to 1 GB

### DIFF
--- a/submit-sbs-jobs.sh
+++ b/submit-sbs-jobs.sh
@@ -98,7 +98,7 @@ do
 	    	echo 'Submitting job '$jobname' with '$nsegments' segments, runnum='$runnum
 
 	    	scriptrun=$script' '$j' '$j' '$runnum' '$nevents' 0 '$prefix' '$i' 1 '$use_sbs_gems' '$DATA_PATH' '$outdirpath' '$run_on_ifarm' '$ANALYZER' '$SBSOFFLINE' '$SBS_REPLAY' '$ANAVER' '$useJLABENV' '$JLAB
-	    	addjobcmd='add-job -workflow '$workflowname' -partition production -name '$jobname' -cores 1 -disk 25GB -ram 3000MB '$inputstring' '$scriptrun
+	    	addjobcmd='add-job -workflow '$workflowname' -partition production -name '$jobname' -cores 1 -disk-scratch 1GB -ram 3000MB '$inputstring' '$scriptrun
 	    
 	    	if [[ $run_on_ifarm -ne 1 ]]; then
 	        	swif2 $addjobcmd


### PR DESCRIPTION
By removing -disk as an option swif2 will automatically allocated 110% of the input space for memory. -disk-scratch allows for memory in excess of this. For GEp, hard coded 25 GB was way too much, but the auto allocation was too little. I've added 1 GB extra (with disk-scratch) to satisfy this. Probably this should be changed for the other SBS experiments as well, but someone should check and optimize those values to be sure.