### PR TITLE
Added Starting event number and other tweaks

### DIFF
--- a/sbs-replay-main.sh
+++ b/sbs-replay-main.sh
@@ -7,6 +7,7 @@
 # Provakar Datta's script                                                   #
 # ---------                                                                 #
 # Sean Jeffas, sj9ry@virginia.edu CREATED 07-24-2023                        #
+# Jacob McMurtry, rby2vw@virginia.edu MODIFED 04-23-2026                    #
 # ---------                                                                 #
 # ** Do not tamper with this sticker! Log any updates to the script above.  #
 # ------------------------------------------------------------------------- #
@@ -18,14 +19,15 @@ source setenv.sh
 runs=$1       # run number 
 prefix=-1     # We will initialize the rest in a second
 run_on_ifarm=-1
+firstevent=-1
 nevents=-1
 maxsegments=-1
 segments_per_job=-1
 use_sbs_gems=             # 0 = no sbs gems, 1 = use sbs gems
 # Workflow name (Not relevant if run_on_ifarm = 1)
-workflowname=GEP_replay_singlerun
+workflowname=gep5_replay_nocorr_0423
 # Specify a directory on volatile to store replayed ROOT files
-outdirpath=/volatile/halla/sbs/mcjacob/GEP/Kin3
+outdirpath=/volatile/halla/sbs/mcjacob/GEP/Kin3/LH2/Apr23/nocorr
 
 
 type=0  # 1 = multi run from txt file, 0 = single run
@@ -42,10 +44,10 @@ elif [[ ! -d $SBS_REPLAY ]]; then
 fi
 
 #Description of how to run if the user puts in a wrong input
-if [ "$#" -ne 6 ] && [ "$#" -ne 3 ] && [ "$#" -ne 4 ] && [ "$#" -ne 7 ]; then
+if [ "$#" -ne 6 ] && [ "$#" -ne 3 ] && [ "$#" -ne 4 ] && [ "$#" -ne 7 ] && [ "$#" -ne 8 ]; then
     echo -e "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     echo -e "This script expects 2 options for inputs:\n"
-    echo -e "Option 1: sbs-replay-main.sh <runnum> <prefix> <nevents> <maxsegments> <segments_per_job> <run_on_ifarm> <use_sbs_gems (optional)>"
+    echo -e "Option 1: sbs-replay-main.sh <runnum> <prefix> <firstevent> <nevents> <maxsegments> <segments_per_job> <run_on_ifarm> <use_sbs_gems (optional)>"
     echo -e "<use_sbs_gems> is optional (off by default)\n"
     echo -e "or\n"
     echo -e "Option 2: sbs-replay-main.sh <runlist> <maxsegments> <segments_per_job> <use_sbs_gems (optional)>"
@@ -74,18 +76,19 @@ fi
 
 # If this is a single run replay then we do that
 if [ $type -eq 0 ]; then
-    if [ "$#" -ne 6 ] && [ "$#" -ne 7 ]; then
-	echo -e "!!!! Error, single run replay needs 6 or 7 arguments !!!!"
-	echo -e "sbs-replay-main.sh <runnum> <prefix> <nevents> <maxsegments> <segments_per_job> <run_on_ifarm> <use_sbs_gems (optional)>\n"
+    if [ "$#" -ne 7 ] && [ "$#" -ne 8 ]; then
+	echo -e "!!!! Error, single run replay needs 7 or 8 arguments !!!!"
+	echo -e "sbs-replay-main.sh <runnum> <prefix> <firstevent> <nevents> <maxsegments> <segments_per_job> <run_on_ifarm> <use_sbs_gems (optional)>\n"
 	exit
     fi
     #read in variables expected for a single run replay
     prefix=$2
-    nevents=$3
-    maxsegments=$4 
-    segments_per_job=$5 
-    run_on_ifarm=$6
-    use_sbs_gems=$7
+    firstevent=$3
+    nevents=$4
+    maxsegments=$5 
+    segments_per_job=$6 
+    run_on_ifarm=$7
+    use_sbs_gems=$8
 
     #if use_sbs_gems has no input assume it is 0 (not used)
     if [ -z "$use_sbs_gems" ]
@@ -105,6 +108,7 @@ elif [ $type -eq 1 ]; then   #Otherwise do a runlist replay
 	exit
     fi
     nevents=-1
+    firstevent=0
     maxsegments=$2 
     segments_per_job=$3 
     use_sbs_gems=$4
@@ -214,7 +218,7 @@ fi
 
 #if a single run then we do a single job
 if [ $type -eq 0 ]; then
-    $SCRIPT_DIR'/submit-sbs-jobs.sh' $runs $prefix $nevents $maxsegments $segments_per_job $use_sbs_gems $run_on_ifarm $outdirpath $workflowname $SCRIPT_DIR $ANALYZER $SBSOFFLINE $SBS_REPLAY $DATA_PATH $ANAVER $useJLABENV $JLABENV
+    $SCRIPT_DIR'/submit-sbs-jobs.sh' $runs $prefix $firstevent $nevents $maxsegments $segments_per_job $use_sbs_gems $run_on_ifarm $outdirpath $workflowname $SCRIPT_DIR $ANALYZER $SBSOFFLINE $SBS_REPLAY $DATA_PATH $ANAVER $useJLABENV $JLABENV
 fi
 
 
@@ -228,7 +232,7 @@ if [ $type -eq 1 ]; then
 	    line_num=$((line_num + 1))
 	    continue
 	fi
-	$SCRIPT_DIR'/submit-sbs-jobs.sh' $runs $prefix $nevents $maxsegments $segments_per_job $use_sbs_gems $run_on_ifarm $outdirpath $workflowname $SCRIPT_DIR $ANALYZER $SBSOFFLINE $SBS_REPLAY $DATA_PATH $ANAVER $useJLABENV $JLABENV
+	$SCRIPT_DIR'/submit-sbs-jobs.sh' $runs $prefix $firstevent $nevents $maxsegments $segments_per_job $use_sbs_gems $run_on_ifarm $outdirpath $workflowname $SCRIPT_DIR $ANALYZER $SBSOFFLINE $SBS_REPLAY $DATA_PATH $ANAVER $useJLABENV $JLABENV
     done < $runs
 fi
 

--- a/submit-sbs-jobs.sh
+++ b/submit-sbs-jobs.sh
@@ -13,21 +13,22 @@
 
 runnum=$1
 prefix=$2
-nevents=$3
-maxsegments=$4
-segments_per_job=$5
-use_sbs_gems=$6
-run_on_ifarm=$7
-outdirpath=$8
-workflowname=$9
-scriptdir=${10}
-analyzerenv=${11}
-sbsofflineenv=${12}
-sbsreplayenv=${13}
-datapath=${14}
-ANAVER=${15}     # Analyzer version
-useJLABENV=${16} # Use 12gev_env instead of modulefiles?
-JLABENV=${17}    # /site/12gev_phys/softenv.sh version
+nevents=$4
+firstevent=$3	# First event to replay (0 by default)
+maxsegments=$5
+segments_per_job=$6
+use_sbs_gems=$7
+run_on_ifarm=$8
+outdirpath=$9
+workflowname=${10}
+scriptdir=${11}
+analyzerenv=${12}
+sbsofflineenv=${13}
+sbsreplayenv=${14}
+datapath=${15}
+ANAVER=${16}     # Analyzer version
+useJLABENV=${17} # Use 12gev_env instead of modulefiles?
+JLABENV=${18}    # /site/12gev_phys/softenv.sh version
 
 #Set environments from inputs above
 export SCRIPT_DIR=$scriptdir
@@ -97,9 +98,11 @@ do
 	    	jobname=$prefix'_replay_'$runnum'_segment'$i'_stream'$j
 	    	echo 'Submitting job '$jobname' with '$nsegments' segments, runnum='$runnum
 
-	    	scriptrun=$script' '$j' '$j' '$runnum' '$nevents' 0 '$prefix' '$i' 1 '$use_sbs_gems' '$DATA_PATH' '$outdirpath' '$run_on_ifarm' '$ANALYZER' '$SBSOFFLINE' '$SBS_REPLAY' '$ANAVER' '$useJLABENV' '$JLAB
-	    	addjobcmd='add-job -workflow '$workflowname' -partition production -name '$jobname' -cores 1 -disk-scratch 1GB -ram 3000MB '$inputstring' '$scriptrun
+	    	scriptrun=$script' '$j' '$j' '$runnum' '$nevents' '$firstevent' '$prefix' '$i' 1 '$use_sbs_gems' '$DATA_PATH' '$outdirpath' '$run_on_ifarm' '$ANALYZER' '$SBSOFFLINE' '$SBS_REPLAY' '$ANAVER' '$useJLABENV' '$JLAB
+	    	#addjobcmd='add-job -workflow '$workflowname' -partition production -name '$jobname' -cores 1 -disk 25GB -ram 3000MB '$inputstring' '$scriptrun
+	    	addjobcmd='add-job -workflow '$workflowname' -partition production -name '$jobname' -cores 1 -disk-scratch 1GB -ram 3000MB -time 12h '$inputstring' '$scriptrun
 	    
+
 	    	if [[ $run_on_ifarm -ne 1 ]]; then
 	        	swif2 $addjobcmd
 			#echo $addjobcmd
@@ -123,10 +126,10 @@ do
 	    echo 'Submitting job '$jobname' with '$nsegments' segments, runnum='$runnum
 	    #echo 'Input string = '$inputstring
 	    
-	    scriptrun=$script' 2 0 '$runnum' '$nevents' 0 '$prefix' '$firstsegment' '$nsegments' '$use_sbs_gems' '$DATA_PATH' '$outdirpath' '$run_on_ifarm' '$ANALYZER' '$SBSOFFLINE' '$SBS_REPLAY' '$ANAVER' '$useJLABENV' '$JLABENV
+	    scriptrun=$script' 2 0 '$runnum' '$nevents' '$firstevent' '$prefix' '$firstsegment' '$nsegments' '$use_sbs_gems' '$DATA_PATH' '$outdirpath' '$run_on_ifarm' '$ANALYZER' '$SBSOFFLINE' '$SBS_REPLAY' '$ANAVER' '$useJLABENV' '$JLABENV
 	    #echo 'Script Run = '$scriptrun
-	    addjobcmd='add-job -workflow '$workflowname' -partition production -name '$jobname' -cores 1 -disk 25GB -ram 3000MB '$inputstring' '$scriptrun
-	    
+	    addjobcmd='add-job -workflow '$workflowname' -partition production -name '$jobname' -cores 1 -disk-scratch 1GB -ram 3000MB -time 12h '$inputstring' '$scriptrun
+	
 	    if [[ $run_on_ifarm -ne 1 ]]; then
 	        swif2 $addjobcmd
 		#echo $addjobcmd
@@ -144,8 +147,8 @@ do
 	    echo 'Submitting job '$jobname' with '$nsegments' segments, runnum = '$runnum
 #	    echo 'Input string = "'$inputstring'"'
 
-	    scriptrun=$script' 0 0 '$runnum' '$nevents' 0 '$prefix' '$firstsegment' '$nsegments' '$use_sbs_gems' '$DATA_PATH' '$outdirpath' '$run_on_ifarm' '$ANALYZER' '$SBSOFFLINE' '$SBS_REPLAY' '$ANAVER' '$useJLABENV' '$JLABENV
-	    addjobcmd='add-job -workflow '$workflowname' -partition production -name '$jobname' -cores 1 -disk 25GB -ram 3000MB '$inputstring' '$scriptrun
+	    scriptrun=$script' 0 0 '$runnum' '$nevents' '$firstevent' '$prefix' '$firstsegment' '$nsegments' '$use_sbs_gems' '$DATA_PATH' '$outdirpath' '$run_on_ifarm' '$ANALYZER' '$SBSOFFLINE' '$SBS_REPLAY' '$ANAVER' '$useJLABENV' '$JLABENV
+	    addjobcmd='add-job -workflow '$workflowname' -partition production -name '$jobname' -cores 1 -disk-scratch 1GB -ram 3000MB -time 12h '$inputstring' '$scriptrun
 
 	    if [[ $run_on_ifarm -ne 1 ]]; then
 	        swif2 $addjobcmd


### PR DESCRIPTION
Updated the memory requirement for other SBS (i.e. GEn, GEn-RP, & GMn) jobs to standardize at 1GB as suggested by Andrew Puckett.

As of 4-21-2026, farm jobs have a default wall time of 12h. I've added this time parameter to the job submission section set to this default value. For longer jobs (e.g. GEp replays), this parameter can be changed to request longer wall times up to 48h.

In the same vein, I have added the starting event number as a variable input for job submissions. This makes it easier to break up jobs when using single run submissions (useful for GEp high current runs) to ensure jobs finish within the allowed time. This is done, for example, by specifying firstevent=0 nevents=10000 to do the first 10000 events (0-9999) and then firstevent=10000 nevents=10000 to do the second 10000 events (10000-19999), etc..